### PR TITLE
TRITON-2495 Syslog support for Cloud Load Balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Moirai supports the following keys:
   (e.g., `198.51.100.0/24`) that are allowed to access the metrics endpoint.
 * `cloud.tritoncompute:metrics_port` - Port number for the metrics endpoint.
   Defaults to `8405` if not specified.
-* `cloud.tritoncompute:syslog` - Remote syslog server endpoint in `IP:PORT` format
-  (e.g., `10.11.28.101:30514`). When configured, HAProxy will forward logs to this
-  server in addition to local logging.
+* `cloud.tritoncompute:syslog` - Remote syslog server endpoint in `HOST:PORT` format
+  (e.g., `syslog.example.com:514` or `10.11.28.101:30514`). When configured, HAProxy
+  will forward logs to this server in addition to local logging.
 
 Metadata keys can be added post-provision. The load balancer will reconfigure
 itself shortly after the metadata is updated.
@@ -188,8 +188,9 @@ logging and monitoring.
 
 ### Syslog Metadata Format
 
-The `cloud.tritoncompute:syslog` value must be in `IP:PORT` format:
-- Example: `10.11.28.101:30514`
+The `cloud.tritoncompute:syslog` value must be in `HOST:PORT` format:
+- Example with IP: `10.11.28.101:30514`
+- Example with hostname: `syslog.example.com:514`
 
 ### Syslog Behavior
 
@@ -197,9 +198,9 @@ The `cloud.tritoncompute:syslog` value must be in `IP:PORT` format:
   the specified remote syslog server
 - The load balancer's hostname will be included in syslog messages
   (`log-send-hostname` is enabled)
-- The metadata is validated to ensure it's a valid IP address and port
-- Port must be between 1 and 65534
-- Invalid values are ignored and logged
+- The metadata accepts both hostnames and IP addresses
+- Any non-empty value in `HOST:PORT` format is accepted
+- Empty values are ignored
 
 ### Dynamic Updates
 
@@ -362,6 +363,9 @@ curl http://frontend-syslog.svc.${UUID?}.${CNS_DOMAIN?}/hostname.txt
 
 # Update syslog configuration dynamically
 triton instance metadata update frontend-syslog cloud.tritoncompute:syslog=192.168.1.10:514
+
+# Update syslog to use hostname
+triton instance metadata update frontend-syslog cloud.tritoncompute:syslog=syslog.example.com:514
 
 # Remove syslog forwarding
 triton instance metadata delete frontend-syslog cloud.tritoncompute:syslog

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <!--
     Copyright 2025 MNX Cloud, Inc.
+    Copyright 2025 Edgecast Cloud LLC.
 -->
 
 # triton-moirai

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2025 Edgecast Cloud LLC.
 
 use anyhow::{Context, Result};
 use askama::Template;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -735,7 +735,7 @@ pub fn configure_haproxy(real_dir: &Path) -> Result<bool> {
     let rendered_global = global_config
         .render()
         .context("Failed to render global configuration template")?;
-    fs::write(candidate_dir.join("000-global.cfg"), rendered_global)
+    fs::write(candidate_dir.join("000-global.cfg"), &rendered_global)
         .context("Failed to write global config file")?;
 
     // Write other embedded HAProxy config files directly
@@ -834,7 +834,8 @@ pub fn configure_haproxy(real_dir: &Path) -> Result<bool> {
     } else {
         warn!("Candidate config is invalid, keeping current configuration.");
         warn!("HAProxy validation output: {}", validation_output);
-        println!("{}", rendered_config);
+        println!("Global config: {}", rendered_global);
+        println!("Service Config: {}", rendered_config);
         Ok(false)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ pub fn parse_syslog_endpoint(input: &str) -> Option<String> {
         return None;
     }
 
-    // Just return the trimmed input - we trust the user's input
+    // Just return the trimmed input - we will let haproxy check its validity.
     Some(trimmed.to_string())
 }
 

--- a/templates/000-global.cfg.askama
+++ b/templates/000-global.cfg.askama
@@ -17,6 +17,10 @@ global
     master-worker
     mworker-max-reloads 10
     log 127.0.0.1 len 4096 local0
+{%- if let Some(addr) = syslog_endpoint %}{#+ #}
+    log {{addr}} len 4096 local0
+    log-send-hostname
+{%- endif %}
     tune.http.logurilen 3072
     user  nobody
     group nobody

--- a/templates/000-global.cfg.askama
+++ b/templates/000-global.cfg.askama
@@ -6,6 +6,7 @@
 
 #
 # Copyright 2025 MNX Cloud, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 #
 
 #                                                  #

--- a/templates/000-global.cfg.askama
+++ b/templates/000-global.cfg.askama
@@ -54,3 +54,4 @@ global
 
     # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam
     #ssl-dh-param-file /opt/triton/tls/dhparam.pem
+


### PR DESCRIPTION
This change adds support for forwarding HAProxy logs to a remote syslog server via the
`cloud.tritoncompute:syslog` metadata key.

Features:
- Convert 000-global.cfg to an Askama template for dynamic rendering
- Include hostname in syslog messages via log-send-hostname
- Configuration updates dynamically during reconfigure (within ~1 minute)

🤖 Generated with [Claude Code](https://claude.ai/code)