### PR TITLE
TRITON-2529 Add support in CLB for configuring global timeouts via metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The `cloud.tritoncompute:syslog` value must be in `HOST:PORT` format:
 The syslog configuration can be updated dynamically without instance restart:
 ```bash
 # Add or update syslog endpoint
-triton instance metadata update <instance> cloud.tritoncompute:syslog=10.11.28.101:30514
+triton instance metadata set <instance> cloud.tritoncompute:syslog=10.11.28.101:30514
 
 # Remove syslog endpoint
 triton instance metadata delete <instance> cloud.tritoncompute:syslog
@@ -257,15 +257,15 @@ All parameters are optional. Any timeout not specified will use its default valu
 
 ```bash
 # Override only the server timeout (useful for long-running requests)
-triton instance metadata update <instance> \
+triton instance metadata set <instance> \
   cloud.tritoncompute:timeouts='{server:300000}'
 
 # Override multiple timeouts
-triton instance metadata update <instance> \
+triton instance metadata set <instance> \
   cloud.tritoncompute:timeouts='{connect:5000,client:60000,server:180000}'
 
 # Override all timeouts
-triton instance metadata update <instance> \
+triton instance metadata set <instance> \
   cloud.tritoncompute:timeouts='{queue:100,connect:5000,client:60000,server:180000}'
 ```
 
@@ -286,7 +286,7 @@ Timeout configuration can be updated dynamically without instance restart:
 
 ```bash
 # Update timeouts
-triton instance metadata update <instance> cloud.tritoncompute:timeouts='{server:300000}'
+triton instance metadata set <instance> cloud.tritoncompute:timeouts='{server:300000}'
 
 # Remove custom timeouts (reverts to defaults)
 triton instance metadata delete <instance> cloud.tritoncompute:timeouts
@@ -458,10 +458,10 @@ triton instance create -w -t triton.cns.services=frontend-syslog \
 curl http://frontend-syslog.svc.${UUID?}.${CNS_DOMAIN?}/hostname.txt
 
 # Update syslog configuration dynamically
-triton instance metadata update frontend-syslog cloud.tritoncompute:syslog=192.168.1.10:514
+triton instance metadata set frontend-syslog cloud.tritoncompute:syslog=192.168.1.10:514
 
 # Update syslog to use hostname
-triton instance metadata update frontend-syslog cloud.tritoncompute:syslog=syslog.example.com:514
+triton instance metadata set frontend-syslog cloud.tritoncompute:syslog=syslog.example.com:514
 
 # Remove syslog forwarding
 triton instance metadata delete frontend-syslog cloud.tritoncompute:syslog

--- a/README.md
+++ b/README.md
@@ -239,30 +239,46 @@ The `cloud.tritoncompute:timeouts` value uses a JSON-like syntax with key:value 
 enclosed in curly braces:
 
 ```
-{queue:0,connect:5000,client:60000,server:180000}
+{queue:0,connect:5000,client:60s,server:180000ms}
 ```
 
 All parameters are optional. Any timeout not specified will use its default value.
 
+### Timeout Value Formats
+
+Timeout values can be specified in three formats:
+
+| Format | Description | Example |
+|--------|-------------|---------|
+| Plain number | Milliseconds | `5000` = 5000ms |
+| Number with `ms` | Milliseconds (explicit) | `5000ms` = 5000ms |
+| Number with `s` | Seconds | `60s` = 60000ms |
+
 ### Supported Timeout Parameters
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `queue`   | 0       | Time (ms) to wait in queue for a connection slot. 0 = unlimited |
-| `connect` | 2000    | Time (ms) to wait for a connection to be established to a backend |
-| `client`  | 55000   | Client inactivity timeout (ms) |
-| `server`  | 120000  | Server response timeout (ms) |
+| Parameter | Default | Max | Description |
+|-----------|---------|-----|-------------|
+| `queue`   | 0       | - | Time to wait in queue for a connection slot. 0 = unlimited |
+| `connect` | 2000    | - | Time to wait for a connection to be established to a backend |
+| `client`  | 55000   | 60 min | Client inactivity timeout |
+| `server`  | 120000  | 60 min | Server response timeout |
+
+**Note:** Client and server timeouts are clamped to a maximum of 60 minutes (3600000ms).
 
 ### Timeout Examples
 
 ```bash
-# Override only the server timeout (useful for long-running requests)
+# Override server timeout using seconds
+triton instance metadata set <instance> \
+  cloud.tritoncompute:timeouts='{server:300s}'
+
+# Override server timeout using milliseconds (equivalent to above)
 triton instance metadata set <instance> \
   cloud.tritoncompute:timeouts='{server:300000}'
 
-# Override multiple timeouts
+# Mix different formats
 triton instance metadata set <instance> \
-  cloud.tritoncompute:timeouts='{connect:5000,client:60000,server:180000}'
+  cloud.tritoncompute:timeouts='{connect:5s,client:60s,server:180000ms}'
 
 # Override all timeouts
 triton instance metadata set <instance> \
@@ -275,7 +291,7 @@ triton instance metadata set <instance> \
 triton instance create -w -t triton.cns.services=frontend \
   -m cloud.tritoncompute:portmap="http://80:web.svc.${UUID?}.${CNS_DOMAIN?}:80" \
   -m cloud.tritoncompute:loadbalancer=true \
-  -m cloud.tritoncompute:timeouts='{server:180000}' \
+  -m cloud.tritoncompute:timeouts='{server:180s}' \
   -n frontend \
   ${IMAGE?} ${PACKAGE?}
 ```
@@ -285,8 +301,8 @@ triton instance create -w -t triton.cns.services=frontend \
 Timeout configuration can be updated dynamically without instance restart:
 
 ```bash
-# Update timeouts
-triton instance metadata set <instance> cloud.tritoncompute:timeouts='{server:300000}'
+# Update timeouts (using seconds)
+triton instance metadata set <instance> cloud.tritoncompute:timeouts='{server:300s}'
 
 # Remove custom timeouts (reverts to defaults)
 triton instance metadata delete <instance> cloud.tritoncompute:timeouts

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Moirai supports the following keys:
 * `cloud.tritoncompute:syslog` - Remote syslog server endpoint in `HOST:PORT` format
   (e.g., `syslog.example.com:514` or `10.11.28.101:30514`). When configured, HAProxy
   will forward logs to this server in addition to local logging.
+* `cloud.tritoncompute:timeouts` - Custom HAProxy timeout values in milliseconds.
+  Uses JSON-like syntax (e.g., `{server:180000}`). See Timeout Configuration section below.
 
 Metadata keys can be added post-provision. The load balancer will reconfigure
 itself shortly after the metadata is updated.
@@ -220,6 +222,74 @@ triton instance metadata update <instance> cloud.tritoncompute:syslog=10.11.28.1
 
 # Remove syslog endpoint
 triton instance metadata delete <instance> cloud.tritoncompute:syslog
+```
+
+The load balancer will detect the metadata change and reconfigure HAProxy within
+approximately one minute.
+
+## Timeout Configuration
+
+The load balancer uses default HAProxy timeout values that work well for most use cases.
+However, you can override these timeouts by setting the `cloud.tritoncompute:timeouts`
+metadata key.
+
+### Timeout Metadata Format
+
+The `cloud.tritoncompute:timeouts` value uses a JSON-like syntax with key:value pairs
+enclosed in curly braces:
+
+```
+{queue:0,connect:5000,client:60000,server:180000}
+```
+
+All parameters are optional. Any timeout not specified will use its default value.
+
+### Supported Timeout Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `queue`   | 0       | Time (ms) to wait in queue for a connection slot. 0 = unlimited |
+| `connect` | 2000    | Time (ms) to wait for a connection to be established to a backend |
+| `client`  | 55000   | Client inactivity timeout (ms) |
+| `server`  | 120000  | Server response timeout (ms) |
+
+### Timeout Examples
+
+```bash
+# Override only the server timeout (useful for long-running requests)
+triton instance metadata update <instance> \
+  cloud.tritoncompute:timeouts='{server:300000}'
+
+# Override multiple timeouts
+triton instance metadata update <instance> \
+  cloud.tritoncompute:timeouts='{connect:5000,client:60000,server:180000}'
+
+# Override all timeouts
+triton instance metadata update <instance> \
+  cloud.tritoncompute:timeouts='{queue:100,connect:5000,client:60000,server:180000}'
+```
+
+### Setting Timeouts at Provision Time
+
+```bash
+triton instance create -w -t triton.cns.services=frontend \
+  -m cloud.tritoncompute:portmap="http://80:web.svc.${UUID?}.${CNS_DOMAIN?}:80" \
+  -m cloud.tritoncompute:loadbalancer=true \
+  -m cloud.tritoncompute:timeouts='{server:180000}' \
+  -n frontend \
+  ${IMAGE?} ${PACKAGE?}
+```
+
+### Dynamic Updates
+
+Timeout configuration can be updated dynamically without instance restart:
+
+```bash
+# Update timeouts
+triton instance metadata update <instance> cloud.tritoncompute:timeouts='{server:300000}'
+
+# Remove custom timeouts (reverts to defaults)
+triton instance metadata delete <instance> cloud.tritoncompute:timeouts
 ```
 
 The load balancer will detect the metadata change and reconfigure HAProxy within

--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ Timeout values can be specified in three formats:
 
 **Note:** Client and server timeouts are clamped to a maximum of 60 minutes (3600000ms).
 
+**TCP Mode Note:** When using TCP services (`tcp://` or `tcp-proxy-v2://`), consider setting
+`client` and `server` timeouts to equal values. In TCP mode, HAProxy proxies raw bytes
+bidirectionally without distinguishing request/response phases. When either timeout expires,
+the entire connection closes—having different values can make it confusing which timeout
+triggered the disconnection. See the [HAProxy Blog](https://www.haproxy.com/blog/the-four-essential-sections-of-an-haproxy-configuration#timeout-connect-timeout-client-timeout-server)
+for more details.
+
 ### Timeout Examples
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
+use std::time::Duration;
 
 pub mod certificates;
 
@@ -421,29 +422,54 @@ pub struct GlobalConfig {
 }
 
 // Default timeout values (in milliseconds)
-pub const DEFAULT_TIMEOUT_QUEUE: u32 = 0;
-pub const DEFAULT_TIMEOUT_CONNECT: u32 = 2000;
-pub const DEFAULT_TIMEOUT_CLIENT: u32 = 55000;
-pub const DEFAULT_TIMEOUT_SERVER: u32 = 120000;
+pub const DEFAULT_TIMEOUT_QUEUE_MS: u64 = 0;
+pub const DEFAULT_TIMEOUT_CONNECT_MS: u64 = 2000;
+pub const DEFAULT_TIMEOUT_CLIENT_MS: u64 = 55000;
+pub const DEFAULT_TIMEOUT_SERVER_MS: u64 = 120000;
+
+// Maximum allowed timeout for client/server (60 minutes in milliseconds)
+pub const MAX_TIMEOUT_CLIENT_SERVER_MS: u64 = 60 * 60 * 1000;
 
 /// Configuration for HAProxy timeouts
 ///
-/// All timeout values are in milliseconds.
+/// All timeout values are stored as Duration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimeoutConfig {
-    pub queue: u32,
-    pub connect: u32,
-    pub client: u32,
-    pub server: u32,
+    pub queue: Duration,
+    pub connect: Duration,
+    pub client: Duration,
+    pub server: Duration,
+}
+
+impl TimeoutConfig {
+    /// Returns the queue timeout in milliseconds for HAProxy configuration
+    pub fn queue_ms(&self) -> u64 {
+        self.queue.as_millis() as u64
+    }
+
+    /// Returns the connect timeout in milliseconds for HAProxy configuration
+    pub fn connect_ms(&self) -> u64 {
+        self.connect.as_millis() as u64
+    }
+
+    /// Returns the client timeout in milliseconds for HAProxy configuration
+    pub fn client_ms(&self) -> u64 {
+        self.client.as_millis() as u64
+    }
+
+    /// Returns the server timeout in milliseconds for HAProxy configuration
+    pub fn server_ms(&self) -> u64 {
+        self.server.as_millis() as u64
+    }
 }
 
 impl Default for TimeoutConfig {
     fn default() -> Self {
         Self {
-            queue: DEFAULT_TIMEOUT_QUEUE,
-            connect: DEFAULT_TIMEOUT_CONNECT,
-            client: DEFAULT_TIMEOUT_CLIENT,
-            server: DEFAULT_TIMEOUT_SERVER,
+            queue: Duration::from_millis(DEFAULT_TIMEOUT_QUEUE_MS),
+            connect: Duration::from_millis(DEFAULT_TIMEOUT_CONNECT_MS),
+            client: Duration::from_millis(DEFAULT_TIMEOUT_CLIENT_MS),
+            server: Duration::from_millis(DEFAULT_TIMEOUT_SERVER_MS),
         }
     }
 }
@@ -565,6 +591,35 @@ pub fn is_loadbalancer_enabled(input: &str) -> bool {
     input.trim().eq_ignore_ascii_case("true")
 }
 
+/// Parse a single timeout value string into a Duration
+///
+/// Supports the following formats:
+/// - Plain number: interpreted as milliseconds (e.g., "5000" = 5000ms)
+/// - Number with 'ms' suffix: milliseconds (e.g., "5000ms" = 5000ms)
+/// - Number with 's' suffix: seconds (e.g., "5s" = 5000ms)
+///
+/// # Arguments
+///
+/// * `value` - The timeout value string to parse
+///
+/// # Returns
+///
+/// Some(Duration) if parsing succeeds, None if the format is invalid
+fn parse_timeout_value(value: &str) -> Option<Duration> {
+    let trimmed = value.trim();
+
+    if let Some(stripped) = trimmed.strip_suffix("ms") {
+        // Milliseconds with explicit suffix
+        stripped.trim().parse::<u64>().ok().map(Duration::from_millis)
+    } else if let Some(stripped) = trimmed.strip_suffix('s') {
+        // Seconds with explicit suffix
+        stripped.trim().parse::<u64>().ok().map(Duration::from_secs)
+    } else {
+        // Plain number = milliseconds (no suffix)
+        trimmed.parse::<u64>().ok().map(Duration::from_millis)
+    }
+}
+
 /// Parse timeout overrides from metadata
 ///
 /// Parses a JSON-like string containing timeout overrides. Any timeout not specified
@@ -573,17 +628,22 @@ pub fn is_loadbalancer_enabled(input: &str) -> bool {
 /// # Format
 ///
 /// ```text
-/// {queue:0,connect:5000,client:60000,server:180000}
+/// {queue:0,connect:5000,client:60s,server:180000ms}
 /// ```
 ///
-/// All parameters are optional. Values are in milliseconds.
+/// All parameters are optional. Values can be specified as:
+/// - Plain numbers: milliseconds (e.g., "5000")
+/// - With 'ms' suffix: milliseconds (e.g., "5000ms")
+/// - With 's' suffix: seconds (e.g., "5s")
+///
+/// Client and server timeouts are clamped to a maximum of 60 minutes.
 ///
 /// # Supported Parameters
 ///
 /// * `queue` - Time to wait in queue for a connection slot (0 = unlimited)
 /// * `connect` - Time to wait for a connection to be established to a backend
-/// * `client` - Client inactivity timeout
-/// * `server` - Server response timeout
+/// * `client` - Client inactivity timeout (max 60 minutes)
+/// * `server` - Server response timeout (max 60 minutes)
 ///
 /// # Arguments
 ///
@@ -591,27 +651,35 @@ pub fn is_loadbalancer_enabled(input: &str) -> bool {
 ///
 /// # Returns
 ///
-/// A TimeoutConfig with values from the input merged with defaults
-pub fn parse_timeouts(input: &str) -> TimeoutConfig {
+/// A TimeoutConfig with values from the input merged with defaults, or an error
+/// if any timeout value is invalid.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - A timeout value has an invalid format (e.g., "5min", "abc")
+/// - A timeout parameter format is invalid (missing colon)
+/// - An unknown timeout parameter is specified
+pub fn parse_timeouts(input: &str) -> Result<TimeoutConfig> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
-        return TimeoutConfig::default();
+        return Ok(TimeoutConfig::default());
     }
 
     // Remove the curly braces if present
     let content = trimmed.trim_start_matches('{').trim_end_matches('}');
     if content.is_empty() {
-        return TimeoutConfig::default();
+        return Ok(TimeoutConfig::default());
     }
 
     let mut config = TimeoutConfig::default();
+    let max_client_server = Duration::from_millis(MAX_TIMEOUT_CLIENT_SERVER_MS);
 
     // Split by comma and parse each key:value pair
     for pair in content.split(',') {
         let parts: Vec<&str> = pair.splitn(2, ':').collect();
         if parts.len() != 2 {
-            warn!("Invalid timeout parameter format: {}", pair);
-            continue;
+            anyhow::bail!("Invalid timeout parameter format: {}", pair);
         }
 
         let key = parts[0].trim();
@@ -619,40 +687,30 @@ pub fn parse_timeouts(input: &str) -> TimeoutConfig {
 
         match key {
             "queue" => {
-                if let Ok(v) = value.parse::<u32>() {
-                    config.queue = v;
-                } else {
-                    warn!("Invalid queue timeout value: {}", value);
-                }
+                config.queue = parse_timeout_value(value)
+                    .ok_or_else(|| anyhow::anyhow!("Invalid queue timeout value: {}", value))?;
             }
             "connect" => {
-                if let Ok(v) = value.parse::<u32>() {
-                    config.connect = v;
-                } else {
-                    warn!("Invalid connect timeout value: {}", value);
-                }
+                config.connect = parse_timeout_value(value)
+                    .ok_or_else(|| anyhow::anyhow!("Invalid connect timeout value: {}", value))?;
             }
             "client" => {
-                if let Ok(v) = value.parse::<u32>() {
-                    config.client = v;
-                } else {
-                    warn!("Invalid client timeout value: {}", value);
-                }
+                let duration = parse_timeout_value(value)
+                    .ok_or_else(|| anyhow::anyhow!("Invalid client timeout value: {}", value))?;
+                config.client = duration.min(max_client_server);
             }
             "server" => {
-                if let Ok(v) = value.parse::<u32>() {
-                    config.server = v;
-                } else {
-                    warn!("Invalid server timeout value: {}", value);
-                }
+                let duration = parse_timeout_value(value)
+                    .ok_or_else(|| anyhow::anyhow!("Invalid server timeout value: {}", value))?;
+                config.server = duration.min(max_client_server);
             }
             _ => {
-                warn!("Unknown timeout parameter: {}", key);
+                anyhow::bail!("Unknown timeout parameter: {}", key);
             }
         }
     }
 
-    config
+    Ok(config)
 }
 
 /// Parse the syslog endpoint from metadata
@@ -877,7 +935,7 @@ pub fn configure_haproxy(real_dir: &Path) -> Result<bool> {
 
     // Get timeout metadata and render defaults configuration
     let timeouts_data = mdata_get(TIMEOUTS_KEY)?;
-    let timeouts = parse_timeouts(&timeouts_data);
+    let timeouts = parse_timeouts(&timeouts_data).context("Failed to parse timeout configuration")?;
     let defaults_config = DefaultsConfig { timeouts };
     let rendered_defaults = defaults_config
         .render()
@@ -2010,90 +2068,94 @@ backend be0
     #[test]
     fn test_parse_timeouts_empty() {
         // Empty string should return defaults
-        let config = parse_timeouts("");
+        let config = parse_timeouts("").unwrap();
         assert_eq!(config, TimeoutConfig::default());
 
         // Whitespace only should return defaults
-        let config = parse_timeouts("   ");
+        let config = parse_timeouts("   ").unwrap();
         assert_eq!(config, TimeoutConfig::default());
 
         // Empty braces should return defaults
-        let config = parse_timeouts("{}");
+        let config = parse_timeouts("{}").unwrap();
         assert_eq!(config, TimeoutConfig::default());
     }
 
     #[test]
     fn test_parse_timeouts_full() {
         // Test with all timeout values specified
-        let config = parse_timeouts("{queue:100,connect:5000,client:60000,server:180000}");
-        assert_eq!(config.queue, 100);
-        assert_eq!(config.connect, 5000);
-        assert_eq!(config.client, 60000);
-        assert_eq!(config.server, 180000);
+        let config = parse_timeouts("{queue:100,connect:5000,client:60000,server:180000}").unwrap();
+        assert_eq!(config.queue_ms(), 100);
+        assert_eq!(config.connect_ms(), 5000);
+        assert_eq!(config.client_ms(), 60000);
+        assert_eq!(config.server_ms(), 180000);
     }
 
     #[test]
     fn test_parse_timeouts_partial() {
         // Test with only some values specified - others should use defaults
-        let config = parse_timeouts("{connect:5000,server:180000}");
-        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
-        assert_eq!(config.connect, 5000);
-        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
-        assert_eq!(config.server, 180000);
+        let config = parse_timeouts("{connect:5000,server:180000}").unwrap();
+        assert_eq!(config.queue_ms(), DEFAULT_TIMEOUT_QUEUE_MS);
+        assert_eq!(config.connect_ms(), 5000);
+        assert_eq!(config.client_ms(), DEFAULT_TIMEOUT_CLIENT_MS);
+        assert_eq!(config.server_ms(), 180000);
     }
 
     #[test]
     fn test_parse_timeouts_single() {
         // Test with single timeout override
-        let config = parse_timeouts("{server:300000}");
-        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
-        assert_eq!(config.connect, DEFAULT_TIMEOUT_CONNECT);
-        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
-        assert_eq!(config.server, 300000);
+        let config = parse_timeouts("{server:300000}").unwrap();
+        assert_eq!(config.queue_ms(), DEFAULT_TIMEOUT_QUEUE_MS);
+        assert_eq!(config.connect_ms(), DEFAULT_TIMEOUT_CONNECT_MS);
+        assert_eq!(config.client_ms(), DEFAULT_TIMEOUT_CLIENT_MS);
+        assert_eq!(config.server_ms(), 300000);
     }
 
     #[test]
     fn test_parse_timeouts_with_whitespace() {
         // Test with whitespace around values
-        let config = parse_timeouts("{ queue : 50 , connect : 3000 }");
-        assert_eq!(config.queue, 50);
-        assert_eq!(config.connect, 3000);
-        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
-        assert_eq!(config.server, DEFAULT_TIMEOUT_SERVER);
+        let config = parse_timeouts("{ queue : 50 , connect : 3000 }").unwrap();
+        assert_eq!(config.queue_ms(), 50);
+        assert_eq!(config.connect_ms(), 3000);
+        assert_eq!(config.client_ms(), DEFAULT_TIMEOUT_CLIENT_MS);
+        assert_eq!(config.server_ms(), DEFAULT_TIMEOUT_SERVER_MS);
     }
 
     #[test]
     fn test_parse_timeouts_without_braces() {
         // Test without braces (should still work)
-        let config = parse_timeouts("queue:100,connect:5000");
-        assert_eq!(config.queue, 100);
-        assert_eq!(config.connect, 5000);
+        let config = parse_timeouts("queue:100,connect:5000").unwrap();
+        assert_eq!(config.queue_ms(), 100);
+        assert_eq!(config.connect_ms(), 5000);
     }
 
     #[test]
     fn test_parse_timeouts_invalid_values() {
-        // Invalid values should be ignored and default used
-        let config = parse_timeouts("{queue:abc,connect:5000}");
-        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE); // default because invalid
-        assert_eq!(config.connect, 5000);
+        // Invalid values should cause an error
+        let result = parse_timeouts("{queue:abc,connect:5000}");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid queue timeout value"));
+
+        // Invalid suffix should cause an error
+        let result = parse_timeouts("{server:5min}");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid server timeout value"));
     }
 
     #[test]
     fn test_parse_timeouts_unknown_keys() {
-        // Unknown keys should be ignored
-        let config = parse_timeouts("{unknown:123,connect:5000}");
-        assert_eq!(config.connect, 5000);
-        // Default values for others
-        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
+        // Unknown keys should cause an error
+        let result = parse_timeouts("{unknown:123,connect:5000}");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown timeout parameter"));
     }
 
     #[test]
     fn test_timeout_config_default() {
         let config = TimeoutConfig::default();
-        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
-        assert_eq!(config.connect, DEFAULT_TIMEOUT_CONNECT);
-        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
-        assert_eq!(config.server, DEFAULT_TIMEOUT_SERVER);
+        assert_eq!(config.queue_ms(), DEFAULT_TIMEOUT_QUEUE_MS);
+        assert_eq!(config.connect_ms(), DEFAULT_TIMEOUT_CONNECT_MS);
+        assert_eq!(config.client_ms(), DEFAULT_TIMEOUT_CLIENT_MS);
+        assert_eq!(config.server_ms(), DEFAULT_TIMEOUT_SERVER_MS);
     }
 
     #[test]
@@ -2118,10 +2180,10 @@ backend be0
         // Test with custom timeouts
         let defaults_config = DefaultsConfig {
             timeouts: TimeoutConfig {
-                queue: 100,
-                connect: 5000,
-                client: 60000,
-                server: 180000,
+                queue: Duration::from_millis(100),
+                connect: Duration::from_millis(5000),
+                client: Duration::from_millis(60000),
+                server: Duration::from_millis(180000),
             },
         };
         let rendered = defaults_config
@@ -2133,5 +2195,79 @@ backend be0
         assert!(rendered.contains("timeout connect 5000"));
         assert!(rendered.contains("timeout client  60000"));
         assert!(rendered.contains("timeout server  180000"));
+    }
+
+    #[test]
+    fn test_parse_timeout_value_milliseconds() {
+        // Plain numbers should be parsed as milliseconds
+        assert_eq!(parse_timeout_value("5000"), Some(Duration::from_millis(5000)));
+        assert_eq!(parse_timeout_value("0"), Some(Duration::from_millis(0)));
+        assert_eq!(parse_timeout_value("100"), Some(Duration::from_millis(100)));
+
+        // With explicit ms suffix
+        assert_eq!(parse_timeout_value("5000ms"), Some(Duration::from_millis(5000)));
+        assert_eq!(parse_timeout_value("0ms"), Some(Duration::from_millis(0)));
+        assert_eq!(parse_timeout_value("100ms"), Some(Duration::from_millis(100)));
+
+        // With whitespace
+        assert_eq!(parse_timeout_value(" 5000 "), Some(Duration::from_millis(5000)));
+        assert_eq!(parse_timeout_value(" 5000 ms"), Some(Duration::from_millis(5000)));
+    }
+
+    #[test]
+    fn test_parse_timeout_value_seconds() {
+        // With s suffix should be parsed as seconds
+        assert_eq!(parse_timeout_value("5s"), Some(Duration::from_secs(5)));
+        assert_eq!(parse_timeout_value("60s"), Some(Duration::from_secs(60)));
+        assert_eq!(parse_timeout_value("0s"), Some(Duration::from_secs(0)));
+        assert_eq!(parse_timeout_value(" 30 s"), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn test_parse_timeout_value_invalid() {
+        // Invalid values should return None
+        assert_eq!(parse_timeout_value("abc"), None);
+        assert_eq!(parse_timeout_value("5x"), None);
+        assert_eq!(parse_timeout_value(""), None);
+        assert_eq!(parse_timeout_value("-5"), None);
+    }
+
+    #[test]
+    fn test_parse_timeouts_with_suffixes() {
+        // Test with millisecond suffixes
+        let config = parse_timeouts("{queue:100ms,connect:5000ms}").unwrap();
+        assert_eq!(config.queue_ms(), 100);
+        assert_eq!(config.connect_ms(), 5000);
+
+        // Test with second suffixes
+        let config = parse_timeouts("{client:60s,server:180s}").unwrap();
+        assert_eq!(config.client_ms(), 60000);
+        assert_eq!(config.server_ms(), 180000);
+
+        // Test with mixed formats
+        let config = parse_timeouts("{queue:100,connect:5s,client:60000ms,server:180s}").unwrap();
+        assert_eq!(config.queue_ms(), 100);
+        assert_eq!(config.connect_ms(), 5000);
+        assert_eq!(config.client_ms(), 60000);
+        assert_eq!(config.server_ms(), 180000);
+    }
+
+    #[test]
+    fn test_parse_timeouts_clamping() {
+        // Client and server should be clamped to MAX_TIMEOUT_CLIENT_SERVER_MS (60 minutes)
+        let very_large_ms = MAX_TIMEOUT_CLIENT_SERVER_MS + 1000000; // More than 60 minutes
+        let config = parse_timeouts(&format!("{{client:{},server:{}}}", very_large_ms, very_large_ms)).unwrap();
+        assert_eq!(config.client_ms(), MAX_TIMEOUT_CLIENT_SERVER_MS);
+        assert_eq!(config.server_ms(), MAX_TIMEOUT_CLIENT_SERVER_MS);
+
+        // Queue and connect should NOT be clamped
+        let config = parse_timeouts(&format!("{{queue:{},connect:{}}}", very_large_ms, very_large_ms)).unwrap();
+        assert_eq!(config.queue_ms(), very_large_ms);
+        assert_eq!(config.connect_ms(), very_large_ms);
+
+        // Test clamping with seconds
+        let config = parse_timeouts("{client:7200s,server:7200s}").unwrap(); // 2 hours in seconds
+        assert_eq!(config.client_ms(), MAX_TIMEOUT_CLIENT_SERVER_MS); // Clamped to 60 minutes
+        assert_eq!(config.server_ms(), MAX_TIMEOUT_CLIENT_SERVER_MS);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub const METRICS_PORT_KEY: &str = "cloud.tritoncompute:metrics_port";
 pub const CERT_NAME_KEY: &str = "cloud.tritoncompute:certificate_name";
 pub const LOADBALANCER_KEY: &str = "cloud.tritoncompute:loadbalancer";
 pub const SYSLOG_KEY: &str = "cloud.tritoncompute:syslog";
+pub const TIMEOUTS_KEY: &str = "cloud.tritoncompute:timeouts";
 
 // File path constants
 pub const FULL_CHAIN_PEM_PATH: &str = "/opt/triton/tls/default/fullchain.pem";
@@ -41,7 +42,6 @@ pub const REAL_CONFIG_DIR: &str = "/opt/local/etc/haproxy.cfg";
 pub const HAPROXY_BINARY: &str = "/opt/local/sbin/haproxy";
 
 // Embedded HAProxy config files
-const HAPROXY_DEFAULTS_CFG: &str = include_str!("../templates/001-defaults.cfg");
 const HAPROXY_RESOLVER_CFG: &str = include_str!("../templates/002-resolver.cfg");
 
 // Path to mdata-get command for illumos
@@ -420,6 +420,41 @@ pub struct GlobalConfig {
     pub syslog_endpoint: Option<String>,
 }
 
+// Default timeout values (in milliseconds)
+pub const DEFAULT_TIMEOUT_QUEUE: u32 = 0;
+pub const DEFAULT_TIMEOUT_CONNECT: u32 = 2000;
+pub const DEFAULT_TIMEOUT_CLIENT: u32 = 55000;
+pub const DEFAULT_TIMEOUT_SERVER: u32 = 120000;
+
+/// Configuration for HAProxy timeouts
+///
+/// All timeout values are in milliseconds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimeoutConfig {
+    pub queue: u32,
+    pub connect: u32,
+    pub client: u32,
+    pub server: u32,
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            queue: DEFAULT_TIMEOUT_QUEUE,
+            connect: DEFAULT_TIMEOUT_CONNECT,
+            client: DEFAULT_TIMEOUT_CLIENT,
+            server: DEFAULT_TIMEOUT_SERVER,
+        }
+    }
+}
+
+/// Template for defaults configuration (includes timeouts)
+#[derive(Template)]
+#[template(path = "001-defaults.cfg.askama")]
+pub struct DefaultsConfig {
+    pub timeouts: TimeoutConfig,
+}
+
 /// Struct to track services that couldn't be parsed or validated
 #[derive(Debug)]
 pub struct RejectedService {
@@ -528,6 +563,96 @@ pub fn parse_max_rs(input: &str) -> usize {
 /// Returns a boolean indicating if the loadbalancer flag is enabled
 pub fn is_loadbalancer_enabled(input: &str) -> bool {
     input.trim().eq_ignore_ascii_case("true")
+}
+
+/// Parse timeout overrides from metadata
+///
+/// Parses a JSON-like string containing timeout overrides. Any timeout not specified
+/// will use the default value.
+///
+/// # Format
+///
+/// ```text
+/// {queue:0,connect:5000,client:60000,server:180000}
+/// ```
+///
+/// All parameters are optional. Values are in milliseconds.
+///
+/// # Supported Parameters
+///
+/// * `queue` - Time to wait in queue for a connection slot (0 = unlimited)
+/// * `connect` - Time to wait for a connection to be established to a backend
+/// * `client` - Client inactivity timeout
+/// * `server` - Server response timeout
+///
+/// # Arguments
+///
+/// * `input` - The timeout configuration string
+///
+/// # Returns
+///
+/// A TimeoutConfig with values from the input merged with defaults
+pub fn parse_timeouts(input: &str) -> TimeoutConfig {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return TimeoutConfig::default();
+    }
+
+    // Remove the curly braces if present
+    let content = trimmed.trim_start_matches('{').trim_end_matches('}');
+    if content.is_empty() {
+        return TimeoutConfig::default();
+    }
+
+    let mut config = TimeoutConfig::default();
+
+    // Split by comma and parse each key:value pair
+    for pair in content.split(',') {
+        let parts: Vec<&str> = pair.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            warn!("Invalid timeout parameter format: {}", pair);
+            continue;
+        }
+
+        let key = parts[0].trim();
+        let value = parts[1].trim();
+
+        match key {
+            "queue" => {
+                if let Ok(v) = value.parse::<u32>() {
+                    config.queue = v;
+                } else {
+                    warn!("Invalid queue timeout value: {}", value);
+                }
+            }
+            "connect" => {
+                if let Ok(v) = value.parse::<u32>() {
+                    config.connect = v;
+                } else {
+                    warn!("Invalid connect timeout value: {}", value);
+                }
+            }
+            "client" => {
+                if let Ok(v) = value.parse::<u32>() {
+                    config.client = v;
+                } else {
+                    warn!("Invalid client timeout value: {}", value);
+                }
+            }
+            "server" => {
+                if let Ok(v) = value.parse::<u32>() {
+                    config.server = v;
+                } else {
+                    warn!("Invalid server timeout value: {}", value);
+                }
+            }
+            _ => {
+                warn!("Unknown timeout parameter: {}", key);
+            }
+        }
+    }
+
+    config
 }
 
 /// Parse the syslog endpoint from metadata
@@ -750,9 +875,17 @@ pub fn configure_haproxy(real_dir: &Path) -> Result<bool> {
     fs::write(candidate_dir.join("000-global.cfg"), &rendered_global)
         .context("Failed to write global config file")?;
 
-    // Write other embedded HAProxy config files directly
-    fs::write(candidate_dir.join("001-defaults.cfg"), HAPROXY_DEFAULTS_CFG)
+    // Get timeout metadata and render defaults configuration
+    let timeouts_data = mdata_get(TIMEOUTS_KEY)?;
+    let timeouts = parse_timeouts(&timeouts_data);
+    let defaults_config = DefaultsConfig { timeouts };
+    let rendered_defaults = defaults_config
+        .render()
+        .context("Failed to render defaults configuration template")?;
+    fs::write(candidate_dir.join("001-defaults.cfg"), &rendered_defaults)
         .context("Failed to write defaults config file")?;
+
+    // Write resolver config file (static)
     fs::write(candidate_dir.join("002-resolver.cfg"), HAPROXY_RESOLVER_CFG)
         .context("Failed to write resolver config file")?;
 
@@ -1872,5 +2005,133 @@ backend be0
         assert!(!service.use_sticky_session());
         assert!(!service.frontend_ssl());
         assert!(!service.backend_ssl());
+    }
+
+    #[test]
+    fn test_parse_timeouts_empty() {
+        // Empty string should return defaults
+        let config = parse_timeouts("");
+        assert_eq!(config, TimeoutConfig::default());
+
+        // Whitespace only should return defaults
+        let config = parse_timeouts("   ");
+        assert_eq!(config, TimeoutConfig::default());
+
+        // Empty braces should return defaults
+        let config = parse_timeouts("{}");
+        assert_eq!(config, TimeoutConfig::default());
+    }
+
+    #[test]
+    fn test_parse_timeouts_full() {
+        // Test with all timeout values specified
+        let config = parse_timeouts("{queue:100,connect:5000,client:60000,server:180000}");
+        assert_eq!(config.queue, 100);
+        assert_eq!(config.connect, 5000);
+        assert_eq!(config.client, 60000);
+        assert_eq!(config.server, 180000);
+    }
+
+    #[test]
+    fn test_parse_timeouts_partial() {
+        // Test with only some values specified - others should use defaults
+        let config = parse_timeouts("{connect:5000,server:180000}");
+        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
+        assert_eq!(config.connect, 5000);
+        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
+        assert_eq!(config.server, 180000);
+    }
+
+    #[test]
+    fn test_parse_timeouts_single() {
+        // Test with single timeout override
+        let config = parse_timeouts("{server:300000}");
+        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
+        assert_eq!(config.connect, DEFAULT_TIMEOUT_CONNECT);
+        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
+        assert_eq!(config.server, 300000);
+    }
+
+    #[test]
+    fn test_parse_timeouts_with_whitespace() {
+        // Test with whitespace around values
+        let config = parse_timeouts("{ queue : 50 , connect : 3000 }");
+        assert_eq!(config.queue, 50);
+        assert_eq!(config.connect, 3000);
+        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
+        assert_eq!(config.server, DEFAULT_TIMEOUT_SERVER);
+    }
+
+    #[test]
+    fn test_parse_timeouts_without_braces() {
+        // Test without braces (should still work)
+        let config = parse_timeouts("queue:100,connect:5000");
+        assert_eq!(config.queue, 100);
+        assert_eq!(config.connect, 5000);
+    }
+
+    #[test]
+    fn test_parse_timeouts_invalid_values() {
+        // Invalid values should be ignored and default used
+        let config = parse_timeouts("{queue:abc,connect:5000}");
+        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE); // default because invalid
+        assert_eq!(config.connect, 5000);
+    }
+
+    #[test]
+    fn test_parse_timeouts_unknown_keys() {
+        // Unknown keys should be ignored
+        let config = parse_timeouts("{unknown:123,connect:5000}");
+        assert_eq!(config.connect, 5000);
+        // Default values for others
+        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
+    }
+
+    #[test]
+    fn test_timeout_config_default() {
+        let config = TimeoutConfig::default();
+        assert_eq!(config.queue, DEFAULT_TIMEOUT_QUEUE);
+        assert_eq!(config.connect, DEFAULT_TIMEOUT_CONNECT);
+        assert_eq!(config.client, DEFAULT_TIMEOUT_CLIENT);
+        assert_eq!(config.server, DEFAULT_TIMEOUT_SERVER);
+    }
+
+    #[test]
+    fn test_defaults_config_rendering() {
+        // Test with default timeouts
+        let defaults_config = DefaultsConfig {
+            timeouts: TimeoutConfig::default(),
+        };
+        let rendered = defaults_config
+            .render()
+            .expect("Failed to render defaults config");
+
+        // Check that the rendered template includes default timeout values
+        assert!(rendered.contains("timeout queue   0"));
+        assert!(rendered.contains("timeout connect 2000"));
+        assert!(rendered.contains("timeout client  55000"));
+        assert!(rendered.contains("timeout server  120000"));
+    }
+
+    #[test]
+    fn test_defaults_config_rendering_custom_timeouts() {
+        // Test with custom timeouts
+        let defaults_config = DefaultsConfig {
+            timeouts: TimeoutConfig {
+                queue: 100,
+                connect: 5000,
+                client: 60000,
+                server: 180000,
+            },
+        };
+        let rendered = defaults_config
+            .render()
+            .expect("Failed to render defaults config");
+
+        // Check that the rendered template includes custom timeout values
+        assert!(rendered.contains("timeout queue   100"));
+        assert!(rendered.contains("timeout connect 5000"));
+        assert!(rendered.contains("timeout client  60000"));
+        assert!(rendered.contains("timeout server  180000"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,65 @@ const HAPROXY_RESOLVER_CFG: &str = include_str!("../templates/002-resolver.cfg")
 // Path to mdata-get command for illumos
 pub const MDATA_GET_PATH: &str = "/usr/sbin/mdata-get";
 
-// Type alias for health check parameters tuple
-type HealthCheckParams = (Option<String>, Option<u16>, Option<u16>, Option<u16>);
+/// Keys for health check configuration parameters
+#[derive(strum::EnumString)]
+#[strum(serialize_all = "lowercase")]
+enum HealthCheckKey {
+    Check,
+    Port,
+    Rise,
+    Fall,
+}
+
+/// Parsed health check parameters
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct HealthCheckConfig {
+    pub check: Option<String>,
+    pub port: Option<u16>,
+    pub rise: Option<u16>,
+    pub fall: Option<u16>,
+}
+
+impl HealthCheckConfig {
+    /// Try to set a field from a key-value pair.
+    /// Returns Ok(true) if the key was recognized, Ok(false) if unknown (logged as warning).
+    /// Returns Err for known keys with invalid values.
+    fn set_from_kv(&mut self, key: &str, value: &str) -> std::result::Result<bool, String> {
+        let Ok(health_key) = HealthCheckKey::from_str(key) else {
+            warn!("Unknown health check parameter '{}' ignored", key);
+            return Ok(false);
+        };
+
+        match health_key {
+            HealthCheckKey::Check => {
+                if value.is_empty() {
+                    return Err("Health check endpoint cannot be empty".into());
+                }
+                self.check = Some(value.to_string());
+            }
+            HealthCheckKey::Port => {
+                self.port = Some(
+                    parse_and_validate_port(value, "health check").map_err(|e| e.to_string())?,
+                );
+            }
+            HealthCheckKey::Rise => {
+                self.rise = Some(
+                    value
+                        .parse()
+                        .map_err(|_| format!("Invalid rise value: {}", value))?,
+                );
+            }
+            HealthCheckKey::Fall => {
+                self.fall = Some(
+                    value
+                        .parse()
+                        .map_err(|_| format!("Invalid fall value: {}", value))?,
+                );
+            }
+        }
+        Ok(true)
+    }
+}
 
 #[derive(
     strum::Display,
@@ -239,22 +296,21 @@ impl FromStr for Service {
         let (listen_port, backend_name, backend_port) = parse_service_parts(service_part)?;
 
         // Parse health check parameters if present
-        let (http_check_endpoint, check_port, check_rise, check_fall) =
-            if let Some(params) = health_params {
-                parse_health_check_params(params)?
-            } else {
-                (None, None, None, None)
-            };
+        let health = if let Some(params) = health_params {
+            parse_health_check_params(params)?
+        } else {
+            HealthCheckConfig::default()
+        };
 
         Ok(Service {
             service_type,
             listen_port,
             backend_name,
             backend_port,
-            http_check_endpoint,
-            check_port,
-            check_rise,
-            check_fall,
+            http_check_endpoint: health.check,
+            check_port: health.port,
+            check_rise: health.rise,
+            check_fall: health.fall,
         })
     }
 }
@@ -315,6 +371,32 @@ fn parse_and_validate_port(
         })
 }
 
+/// Parse a mini JSON-like string of key:value pairs
+///
+/// Accepts format: `{key1:value1,key2:value2}` or `key1:value1,key2:value2`
+/// Braces are optional. Empty pairs are skipped.
+///
+/// # Returns
+/// Vec of (key, value) tuples on success, or error message if any pair is malformed.
+fn parse_kv_pairs(s: &str) -> std::result::Result<Vec<(&str, &str)>, String> {
+    let content = s.trim().trim_start_matches('{').trim_end_matches('}');
+    let mut pairs = Vec::new();
+
+    for pair in content.split(',') {
+        if pair.trim().is_empty() {
+            continue;
+        }
+        let mut parts = pair.splitn(2, ':');
+        let key = parts.next().map(str::trim).unwrap_or("");
+        let value = parts
+            .next()
+            .map(str::trim)
+            .ok_or_else(|| format!("Invalid parameter format (missing ':'): {}", pair))?;
+        pairs.push((key, value));
+    }
+    Ok(pairs)
+}
+
 /// Parse health check parameters from a JSON-like string.
 ///
 /// This function parses health check configuration parameters embedded in service
@@ -337,67 +419,25 @@ fn parse_and_validate_port(
 ///
 /// # Returns
 ///
-/// A tuple containing `(http_check_endpoint, check_port, check_rise, check_fall)`
-/// where each value is `Some(value)` if specified, or `None` if not provided.
+/// A HealthCheckConfig with fields set from the parsed parameters.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// * The parameter format is invalid (missing colon separator)
 /// * Port values are not valid u16 integers
-/// * Rise/fall values are not valid u16 integers  
-/// * Unknown parameter names are encountered
+/// * Rise/fall values are not valid u16 integers
 /// * The check endpoint is empty
-fn parse_health_check_params(s: &str) -> std::result::Result<HealthCheckParams, Box<dyn StdError>> {
-    // Remove the curly braces
-    let trimmed = s.trim_start_matches('{').trim_end_matches('}');
+///
+/// Unknown parameter names are logged as warnings and ignored.
+fn parse_health_check_params(s: &str) -> std::result::Result<HealthCheckConfig, Box<dyn StdError>> {
+    let mut config = HealthCheckConfig::default();
 
-    let mut http_check_endpoint = None;
-    let mut check_port = None;
-    let mut check_rise = None;
-    let mut check_fall = None;
-
-    // Split by comma and parse each key:value pair
-    for pair in trimmed.split(',') {
-        let parts: Vec<&str> = pair.splitn(2, ':').collect();
-        if parts.len() != 2 {
-            return Err(format!("Invalid health check parameter format: {}", pair).into());
-        }
-
-        let key = parts[0].trim();
-        let value = parts[1].trim();
-
-        match key {
-            "check" => {
-                if value.is_empty() {
-                    return Err("Health check endpoint cannot be empty".into());
-                }
-                http_check_endpoint = Some(value.to_string());
-            }
-            "port" => {
-                check_port = Some(parse_and_validate_port(value, "health check")?);
-            }
-            "rise" => {
-                check_rise = Some(
-                    value
-                        .parse::<u16>()
-                        .map_err(|_| format!("Invalid rise value: {}", value))?,
-                );
-            }
-            "fall" => {
-                check_fall = Some(
-                    value
-                        .parse::<u16>()
-                        .map_err(|_| format!("Invalid fall value: {}", value))?,
-                );
-            }
-            _ => {
-                return Err(format!("Unknown health check parameter: {}", key).into());
-            }
-        }
+    for (key, value) in parse_kv_pairs(s)? {
+        config.set_from_kv(key, value)?;
     }
 
-    Ok((http_check_endpoint, check_port, check_rise, check_fall))
+    Ok(config)
 }
 
 #[derive(Template)]
@@ -430,6 +470,16 @@ pub const DEFAULT_TIMEOUT_SERVER_MS: u64 = 120000;
 // Maximum allowed timeout for client/server (60 minutes in milliseconds)
 pub const MAX_TIMEOUT_CLIENT_SERVER_MS: u64 = 60 * 60 * 1000;
 
+/// Keys for timeout configuration parameters
+#[derive(strum::EnumString)]
+#[strum(serialize_all = "lowercase")]
+enum TimeoutKey {
+    Queue,
+    Connect,
+    Client,
+    Server,
+}
+
 /// Configuration for HAProxy timeouts
 ///
 /// All timeout values are stored as Duration.
@@ -460,6 +510,29 @@ impl TimeoutConfig {
     /// Returns the server timeout in milliseconds for HAProxy configuration
     pub fn server_ms(&self) -> u64 {
         self.server.as_millis() as u64
+    }
+
+    /// Try to set a field from a key-value pair.
+    /// Returns Ok(true) if the key was recognized, Ok(false) if unknown (logged as warning).
+    /// Returns Err for known keys with invalid values.
+    /// Client and server timeouts are clamped to MAX_TIMEOUT_CLIENT_SERVER_MS.
+    fn set_from_kv(&mut self, key: &str, value: &str) -> std::result::Result<bool, String> {
+        let Ok(timeout_key) = TimeoutKey::from_str(key) else {
+            warn!("Unknown timeout parameter '{}' ignored", key);
+            return Ok(false);
+        };
+
+        let duration = parse_timeout_value(value)
+            .ok_or_else(|| format!("Invalid {} timeout value: {}", key, value))?;
+
+        let max_client_server = Duration::from_millis(MAX_TIMEOUT_CLIENT_SERVER_MS);
+        match timeout_key {
+            TimeoutKey::Queue => self.queue = duration,
+            TimeoutKey::Connect => self.connect = duration,
+            TimeoutKey::Client => self.client = duration.min(max_client_server),
+            TimeoutKey::Server => self.server = duration.min(max_client_server),
+        }
+        Ok(true)
     }
 }
 
@@ -663,55 +736,20 @@ fn parse_timeout_value(value: &str) -> Option<Duration> {
 /// Returns an error if:
 /// - A timeout value has an invalid format (e.g., "5min", "abc")
 /// - A timeout parameter format is invalid (missing colon)
-/// - An unknown timeout parameter is specified
+///
+/// Unknown parameter names are logged as warnings and ignored.
 pub fn parse_timeouts(input: &str) -> Result<TimeoutConfig> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return Ok(TimeoutConfig::default());
     }
 
-    // Remove the curly braces if present
-    let content = trimmed.trim_start_matches('{').trim_end_matches('}');
-    if content.is_empty() {
-        return Ok(TimeoutConfig::default());
-    }
-
     let mut config = TimeoutConfig::default();
-    let max_client_server = Duration::from_millis(MAX_TIMEOUT_CLIENT_SERVER_MS);
 
-    // Split by comma and parse each key:value pair
-    for pair in content.split(',') {
-        let parts: Vec<&str> = pair.splitn(2, ':').collect();
-        if parts.len() != 2 {
-            anyhow::bail!("Invalid timeout parameter format: {}", pair);
-        }
-
-        let key = parts[0].trim();
-        let value = parts[1].trim();
-
-        match key {
-            "queue" => {
-                config.queue = parse_timeout_value(value)
-                    .ok_or_else(|| anyhow::anyhow!("Invalid queue timeout value: {}", value))?;
-            }
-            "connect" => {
-                config.connect = parse_timeout_value(value)
-                    .ok_or_else(|| anyhow::anyhow!("Invalid connect timeout value: {}", value))?;
-            }
-            "client" => {
-                let duration = parse_timeout_value(value)
-                    .ok_or_else(|| anyhow::anyhow!("Invalid client timeout value: {}", value))?;
-                config.client = duration.min(max_client_server);
-            }
-            "server" => {
-                let duration = parse_timeout_value(value)
-                    .ok_or_else(|| anyhow::anyhow!("Invalid server timeout value: {}", value))?;
-                config.server = duration.min(max_client_server);
-            }
-            _ => {
-                anyhow::bail!("Unknown timeout parameter: {}", key);
-            }
-        }
+    for (key, value) in parse_kv_pairs(trimmed).map_err(|e| anyhow::anyhow!("{}", e))? {
+        config
+            .set_from_kv(key, value)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
     }
 
     Ok(config)
@@ -1814,41 +1852,81 @@ backend be0
     }
 
     #[test]
+    fn test_parse_kv_pairs() {
+        // Basic parsing with braces
+        let pairs = parse_kv_pairs("{foo:bar,baz:qux}").unwrap();
+        assert_eq!(pairs, vec![("foo", "bar"), ("baz", "qux")]);
+
+        // Without braces
+        let pairs = parse_kv_pairs("foo:bar,baz:qux").unwrap();
+        assert_eq!(pairs, vec![("foo", "bar"), ("baz", "qux")]);
+
+        // Value with colon (splitn(2, ':') preserves it)
+        let pairs = parse_kv_pairs("{check:/health:8080}").unwrap();
+        assert_eq!(pairs, vec![("check", "/health:8080")]);
+
+        // Empty input
+        let pairs = parse_kv_pairs("{}").unwrap();
+        assert!(pairs.is_empty());
+
+        let pairs = parse_kv_pairs("").unwrap();
+        assert!(pairs.is_empty());
+
+        // Whitespace handling
+        let pairs = parse_kv_pairs("{ foo : bar , baz : qux }").unwrap();
+        assert_eq!(pairs, vec![("foo", "bar"), ("baz", "qux")]);
+
+        // Single pair
+        let pairs = parse_kv_pairs("{key:value}").unwrap();
+        assert_eq!(pairs, vec![("key", "value")]);
+
+        // Missing colon should error
+        let result = parse_kv_pairs("{foo}");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("missing ':'"));
+    }
+
+    #[test]
     fn test_parse_health_check_params() {
         // Test full parameters
         let result = parse_health_check_params("{check:/healthz,port:32150,rise:30,fall:1}");
         assert!(result.is_ok());
-        let (check, port, rise, fall) = result.unwrap();
-        assert_eq!(check, Some("/healthz".to_string()));
-        assert_eq!(port, Some(32150));
-        assert_eq!(rise, Some(30));
-        assert_eq!(fall, Some(1));
+        let config = result.unwrap();
+        assert_eq!(config.check, Some("/healthz".to_string()));
+        assert_eq!(config.port, Some(32150));
+        assert_eq!(config.rise, Some(30));
+        assert_eq!(config.fall, Some(1));
 
         // Test partial parameters
         let result = parse_health_check_params("{check:/health,port:8080}");
         assert!(result.is_ok());
-        let (check, port, rise, fall) = result.unwrap();
-        assert_eq!(check, Some("/health".to_string()));
-        assert_eq!(port, Some(8080));
-        assert_eq!(rise, None);
-        assert_eq!(fall, None);
+        let config = result.unwrap();
+        assert_eq!(config.check, Some("/health".to_string()));
+        assert_eq!(config.port, Some(8080));
+        assert_eq!(config.rise, None);
+        assert_eq!(config.fall, None);
 
         // Test only check endpoint
         let result = parse_health_check_params("{check:/}");
         assert!(result.is_ok());
-        let (check, port, rise, fall) = result.unwrap();
-        assert_eq!(check, Some("/".to_string()));
-        assert_eq!(port, None);
-        assert_eq!(rise, None);
-        assert_eq!(fall, None);
+        let config = result.unwrap();
+        assert_eq!(config.check, Some("/".to_string()));
+        assert_eq!(config.port, None);
+        assert_eq!(config.rise, None);
+        assert_eq!(config.fall, None);
 
         // Test invalid format
         let result = parse_health_check_params("{check}");
         assert!(result.is_err());
 
-        // Test unknown parameter
+        // Test unknown parameter (logged as warning, ignored)
         let result = parse_health_check_params("{check:/health,unknown:value}");
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        let config = result.unwrap();
+        assert_eq!(config.check, Some("/health".to_string()));
+        assert_eq!(config.port, None);
+        assert_eq!(config.rise, None);
+        assert_eq!(config.fall, None);
     }
 
     #[test]
@@ -2154,13 +2232,16 @@ backend be0
 
     #[test]
     fn test_parse_timeouts_unknown_keys() {
-        // Unknown keys should cause an error
+        // Unknown keys should be silently ignored
         let result = parse_timeouts("{unknown:123,connect:5000}");
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown timeout parameter"));
+        assert!(result.is_ok());
+        let config = result.unwrap();
+        assert_eq!(config.connect, Duration::from_millis(5000));
+        // Other values should remain at defaults
+        assert_eq!(
+            config.queue,
+            Duration::from_millis(DEFAULT_TIMEOUT_QUEUE_MS)
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,7 +610,11 @@ fn parse_timeout_value(value: &str) -> Option<Duration> {
 
     if let Some(stripped) = trimmed.strip_suffix("ms") {
         // Milliseconds with explicit suffix
-        stripped.trim().parse::<u64>().ok().map(Duration::from_millis)
+        stripped
+            .trim()
+            .parse::<u64>()
+            .ok()
+            .map(Duration::from_millis)
     } else if let Some(stripped) = trimmed.strip_suffix('s') {
         // Seconds with explicit suffix
         stripped.trim().parse::<u64>().ok().map(Duration::from_secs)
@@ -935,7 +939,8 @@ pub fn configure_haproxy(real_dir: &Path) -> Result<bool> {
 
     // Get timeout metadata and render defaults configuration
     let timeouts_data = mdata_get(TIMEOUTS_KEY)?;
-    let timeouts = parse_timeouts(&timeouts_data).context("Failed to parse timeout configuration")?;
+    let timeouts =
+        parse_timeouts(&timeouts_data).context("Failed to parse timeout configuration")?;
     let defaults_config = DefaultsConfig { timeouts };
     let rendered_defaults = defaults_config
         .render()
@@ -2133,12 +2138,18 @@ backend be0
         // Invalid values should cause an error
         let result = parse_timeouts("{queue:abc,connect:5000}");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Invalid queue timeout value"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid queue timeout value"));
 
         // Invalid suffix should cause an error
         let result = parse_timeouts("{server:5min}");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Invalid server timeout value"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid server timeout value"));
     }
 
     #[test]
@@ -2146,7 +2157,10 @@ backend be0
         // Unknown keys should cause an error
         let result = parse_timeouts("{unknown:123,connect:5000}");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Unknown timeout parameter"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown timeout parameter"));
     }
 
     #[test]
@@ -2200,18 +2214,33 @@ backend be0
     #[test]
     fn test_parse_timeout_value_milliseconds() {
         // Plain numbers should be parsed as milliseconds
-        assert_eq!(parse_timeout_value("5000"), Some(Duration::from_millis(5000)));
+        assert_eq!(
+            parse_timeout_value("5000"),
+            Some(Duration::from_millis(5000))
+        );
         assert_eq!(parse_timeout_value("0"), Some(Duration::from_millis(0)));
         assert_eq!(parse_timeout_value("100"), Some(Duration::from_millis(100)));
 
         // With explicit ms suffix
-        assert_eq!(parse_timeout_value("5000ms"), Some(Duration::from_millis(5000)));
+        assert_eq!(
+            parse_timeout_value("5000ms"),
+            Some(Duration::from_millis(5000))
+        );
         assert_eq!(parse_timeout_value("0ms"), Some(Duration::from_millis(0)));
-        assert_eq!(parse_timeout_value("100ms"), Some(Duration::from_millis(100)));
+        assert_eq!(
+            parse_timeout_value("100ms"),
+            Some(Duration::from_millis(100))
+        );
 
         // With whitespace
-        assert_eq!(parse_timeout_value(" 5000 "), Some(Duration::from_millis(5000)));
-        assert_eq!(parse_timeout_value(" 5000 ms"), Some(Duration::from_millis(5000)));
+        assert_eq!(
+            parse_timeout_value(" 5000 "),
+            Some(Duration::from_millis(5000))
+        );
+        assert_eq!(
+            parse_timeout_value(" 5000 ms"),
+            Some(Duration::from_millis(5000))
+        );
     }
 
     #[test]
@@ -2256,12 +2285,20 @@ backend be0
     fn test_parse_timeouts_clamping() {
         // Client and server should be clamped to MAX_TIMEOUT_CLIENT_SERVER_MS (60 minutes)
         let very_large_ms = MAX_TIMEOUT_CLIENT_SERVER_MS + 1000000; // More than 60 minutes
-        let config = parse_timeouts(&format!("{{client:{},server:{}}}", very_large_ms, very_large_ms)).unwrap();
+        let config = parse_timeouts(&format!(
+            "{{client:{},server:{}}}",
+            very_large_ms, very_large_ms
+        ))
+        .unwrap();
         assert_eq!(config.client_ms(), MAX_TIMEOUT_CLIENT_SERVER_MS);
         assert_eq!(config.server_ms(), MAX_TIMEOUT_CLIENT_SERVER_MS);
 
         // Queue and connect should NOT be clamped
-        let config = parse_timeouts(&format!("{{queue:{},connect:{}}}", very_large_ms, very_large_ms)).unwrap();
+        let config = parse_timeouts(&format!(
+            "{{queue:{},connect:{}}}",
+            very_large_ms, very_large_ms
+        ))
+        .unwrap();
         assert_eq!(config.queue_ms(), very_large_ms);
         assert_eq!(config.connect_ms(), very_large_ms);
 

--- a/templates/001-defaults.cfg.askama
+++ b/templates/001-defaults.cfg.askama
@@ -6,6 +6,7 @@
 
 #
 # Copyright 2025 MNX Cloud, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 #
 
 #                                                  #

--- a/templates/001-defaults.cfg.askama
+++ b/templates/001-defaults.cfg.askama
@@ -27,8 +27,8 @@ defaults
     no option httpclose
     no option http-server-close
     retries   1
-    timeout queue   {{ timeouts.queue }}
-    timeout connect {{ timeouts.connect }}
-    timeout client  {{ timeouts.client }}
-    timeout server  {{ timeouts.server }}
+    timeout queue   {{ timeouts.queue_ms() }}
+    timeout connect {{ timeouts.connect_ms() }}
+    timeout client  {{ timeouts.client_ms() }}
+    timeout server  {{ timeouts.server_ms() }}
 

--- a/templates/001-defaults.cfg.askama
+++ b/templates/001-defaults.cfg.askama
@@ -30,3 +30,4 @@ defaults
     timeout connect {{ timeouts.connect }}
     timeout client  {{ timeouts.client }}
     timeout server  {{ timeouts.server }}
+

--- a/templates/001-defaults.cfg.askama
+++ b/templates/001-defaults.cfg.askama
@@ -26,7 +26,7 @@ defaults
     no option httpclose
     no option http-server-close
     retries   1
-    timeout queue   0
-    timeout connect 2000
-    timeout client  55000
-    timeout server  120000
+    timeout queue   {{ timeouts.queue }}
+    timeout connect {{ timeouts.connect }}
+    timeout client  {{ timeouts.client }}
+    timeout server  {{ timeouts.server }}


### PR DESCRIPTION
- Support changing of the global timeout values, for example when your client/server responses are less frequent than every 55s or 120s. Additionally allows the user to match the client/server timeouts when operating in TCP mode as recommended by haproxy [here](https://www.haproxy.com/blog/the-four-essential-sections-of-an-haproxy-configuration#timeout-connect-timeout-client-timeout-server):

> When operating HAProxy in TCP mode, which is set with mode tcp, timeout server should be the same as timeout client. That’s because HAProxy doesn’t know which side is supposed to be speaking and, since both apply all the time, having different values makes confusion more likely.

- Update pre-existing documentation for metadata setting/updating to reflect the proper sub-command.