### PR TITLE
TRITON-2533 Fix Let's Encrypt certificate symlink not being used

### DIFF
--- a/src/certificates.rs
+++ b/src/certificates.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 
 //! # Certificate Management Module
 //!
@@ -39,6 +40,7 @@ use anyhow::{Context, Result};
 use log::{debug, info};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::os::unix::fs as unix_fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -50,6 +52,37 @@ pub const SELF_SIGNED_KEY: &str = "/opt/triton/tls/self-signed/fullchain.pem.key
 pub const SELF_SIGNED_CERT: &str = "/opt/triton/tls/self-signed/fullchain.pem";
 pub const DEFAULT_CERT_DIR: &str = "/opt/triton/tls/default";
 pub const DEHYDRATED_DIR: &str = "/opt/triton/dehydrated";
+
+/// Updates a symlink, removing it first if it already exists
+///
+/// This is a force-update version of symlink creation that will remove
+/// any existing symlink or file at the target path before creating the new symlink.
+///
+/// # Arguments
+///
+/// * `source` - The path the symlink should point to
+/// * `target` - The path where the symlink should be created
+///
+/// # Returns
+///
+/// * `Result<()>` - Ok if successful, Err otherwise
+fn update_symlink(source: &Path, target: &Path) -> Result<()> {
+    // Remove existing symlink or file if present
+    if target.is_symlink() || target.exists() {
+        fs::remove_file(target).context("Failed to remove existing symlink")?;
+        debug!("Removed existing symlink at {}", target.display());
+    }
+
+    // Create the new symlink
+    unix_fs::symlink(source, target).context("Failed to create symlink")?;
+    info!(
+        "Created symlink from {} to {}",
+        target.display(),
+        source.display()
+    );
+
+    Ok(())
+}
 
 /// Configures TLS certificates based on metadata
 ///
@@ -127,6 +160,26 @@ pub fn configure_tls() -> Result<bool> {
         .context("Failed to write stdout to log file")?;
     file.write_all(&output.stderr)
         .context("Failed to write stderr to log file")?;
+
+    // Ensure the default symlink points to the Let's Encrypt certificate directory
+    // Extract the primary domain name (first domain in the cert_subject)
+    let primary_domain = cert_subject
+        .split(',')
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No domain found in certificate subject"))?
+        .trim();
+
+    let tls_dir = Path::new("/opt/triton/tls");
+    let letsencrypt_cert_dir = tls_dir.join(primary_domain);
+    let default_symlink = Path::new(DEFAULT_CERT_DIR);
+
+    // Update the default symlink to point to the Let's Encrypt certificate directory
+    update_symlink(&letsencrypt_cert_dir, default_symlink)?;
+
+    info!(
+        "Updated default symlink to point to Let's Encrypt certificate directory: {}",
+        letsencrypt_cert_dir.display()
+    );
 
     info!("Certificates were updated.");
     Ok(true)

--- a/src/certificates.rs
+++ b/src/certificates.rs
@@ -67,10 +67,26 @@ pub const DEHYDRATED_DIR: &str = "/opt/triton/dehydrated";
 ///
 /// * `Result<()>` - Ok if successful, Err otherwise
 fn update_symlink(source: &Path, target: &Path) -> Result<()> {
-    // Remove existing symlink or file if present
-    if target.is_symlink() || target.exists() {
-        fs::remove_file(target).context("Failed to remove existing symlink")?;
-        debug!("Removed existing symlink at {}", target.display());
+    // Remove existing entry if present
+    if let Ok(meta) = fs::symlink_metadata(target) {
+        let ft = meta.file_type();
+        if ft.is_symlink() {
+            fs::remove_file(target).context("Failed to remove existing symlink")?;
+            debug!("Removed existing symlink at {}", target.display());
+        } else if ft.is_file() {
+            fs::remove_file(target).context("Failed to remove existing file")?;
+            debug!("Removed existing file at {}", target.display());
+        } else if ft.is_dir() {
+            anyhow::bail!(
+                "Cannot create symlink at {}: path is a directory",
+                target.display()
+            );
+        } else {
+            anyhow::bail!(
+                "Cannot create symlink at {}: unexpected file type",
+                target.display()
+            );
+        }
     }
 
     // Create the new symlink

--- a/src/certificates.rs
+++ b/src/certificates.rs
@@ -68,31 +68,55 @@ pub const DEHYDRATED_DIR: &str = "/opt/triton/dehydrated";
 /// * `Result<()>` - Ok if successful, Err otherwise
 fn update_symlink(source: &Path, target: &Path) -> Result<()> {
     // Remove existing entry if present
-    if let Ok(meta) = fs::symlink_metadata(target) {
-        let ft = meta.file_type();
-        if ft.is_symlink() {
-            fs::remove_file(target).context("Failed to remove existing symlink")?;
-            debug!("Removed existing symlink at {}", target.display());
-        } else if ft.is_file() {
-            fs::remove_file(target).context("Failed to remove existing file")?;
-            debug!("Removed existing file at {}", target.display());
-        } else if ft.is_dir() {
-            anyhow::bail!(
-                "Cannot create symlink at {}: path is a directory",
+    match fs::symlink_metadata(target) {
+        Ok(meta) => {
+            let ft = meta.file_type();
+            if ft.is_symlink() {
+                fs::remove_file(target).with_context(|| {
+                    format!("Failed to remove existing symlink at {}", target.display())
+                })?;
+                debug!("Removed existing symlink at {}", target.display());
+            } else if ft.is_file() {
+                fs::remove_file(target).with_context(|| {
+                    format!("Failed to remove existing file at {}", target.display())
+                })?;
+                debug!("Removed existing file at {}", target.display());
+            } else if ft.is_dir() {
+                anyhow::bail!(
+                    "Cannot create symlink at {}: path is a directory",
+                    target.display()
+                );
+            } else {
+                anyhow::bail!(
+                    "Cannot create symlink at {}: unexpected file type",
+                    target.display()
+                );
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Target doesn't exist, which is fine - we'll create the symlink
+            debug!(
+                "No existing entry at {}, creating new symlink",
                 target.display()
             );
-        } else {
-            anyhow::bail!(
-                "Cannot create symlink at {}: unexpected file type",
-                target.display()
-            );
+        }
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("Failed to check existing entry at {}", target.display())
+            });
         }
     }
 
     // Create the new symlink
-    unix_fs::symlink(source, target).context("Failed to create symlink")?;
+    unix_fs::symlink(source, target).with_context(|| {
+        format!(
+            "Failed to create symlink {} -> {}",
+            target.display(),
+            source.display()
+        )
+    })?;
     info!(
-        "Created symlink from {} to {}",
+        "Created symlink {} -> {}",
         target.display(),
         source.display()
     );
@@ -188,6 +212,16 @@ pub fn configure_tls() -> Result<bool> {
     let tls_dir = Path::new("/opt/triton/tls");
     let letsencrypt_cert_dir = tls_dir.join(primary_domain);
     let default_symlink = Path::new(DEFAULT_CERT_DIR);
+
+    // Verify the Let's Encrypt certificate directory exists before creating symlink
+    if !letsencrypt_cert_dir.exists() {
+        return Err(anyhow::anyhow!(
+            "Let's Encrypt certificate directory does not exist: {}. \
+             dehydrated may have failed to obtain certificates for domain: {}",
+            letsencrypt_cert_dir.display(),
+            primary_domain
+        ));
+    }
 
     // Update the default symlink to point to the Let's Encrypt certificate directory
     update_symlink(&letsencrypt_cert_dir, default_symlink)?;

--- a/src/certificates.rs
+++ b/src/certificates.rs
@@ -47,6 +47,7 @@ use std::process::Command;
 use crate::{mdata_get, CERT_NAME_KEY};
 
 // Constants for certificate directories
+pub const TLS_DIR: &str = "/opt/triton/tls";
 pub const SELF_SIGNED_CERT_DIR: &str = "/opt/triton/tls/self-signed";
 pub const SELF_SIGNED_KEY: &str = "/opt/triton/tls/self-signed/fullchain.pem.key";
 pub const SELF_SIGNED_CERT: &str = "/opt/triton/tls/self-signed/fullchain.pem";
@@ -209,7 +210,7 @@ pub fn configure_tls() -> Result<bool> {
         .ok_or_else(|| anyhow::anyhow!("No domain found in certificate subject"))?
         .trim();
 
-    let tls_dir = Path::new("/opt/triton/tls");
+    let tls_dir = Path::new(TLS_DIR);
     let letsencrypt_cert_dir = tls_dir.join(primary_domain);
     let default_symlink = Path::new(DEFAULT_CERT_DIR);
 


### PR DESCRIPTION
After dehydrated successfully obtains Let's Encrypt certificates, ensure the default symlink at /opt/triton/tls/default points to the Let's Encrypt certificate directory instead of remaining pointed at the self-signed directory.

The fix extracts the primary domain name from the certificate subject and updates the symlink to point to /opt/triton/tls/<domain>/ after dehydrated completes successfully.

Originally authored by @Copilot but that made Jenkins very sad.

Fixes #10 